### PR TITLE
Updates handlers to support disabling lock use case

### DIFF
--- a/src/prev7Mappings/mapping.ts
+++ b/src/prev7Mappings/mapping.ts
@@ -1,4 +1,4 @@
-import { Address, Bytes, BigInt } from "@graphprotocol/graph-ts";
+import { Address, Bytes, BigInt, store } from "@graphprotocol/graph-ts";
 import { CancelKey, ExpireKey } from "../../generated/Contract/PublicLock";
 import {
   Lock,
@@ -12,6 +12,8 @@ import {
   OwnershipTransferred,
   PriceChanged,
   PublicLock,
+  Destroy,
+  Disable,
 } from "../../generated/templates/PublicLock/PublicLock";
 
 export function handleLockTransfer(event: OwnershipTransferred): void {
@@ -87,6 +89,20 @@ export function handleExpireKey(event: ExpireKey): void {
     Address.fromString(key.owner)
   );
   key.save();
+}
+
+
+
+export function handleDisable(event: Disable): void {
+  let lockId = event.address.toHex().toString();
+  let lock = Lock.load(lockId) as Lock;
+
+  lock.LockManagers.forEach((lockManager) =>{    
+    let lockManagerId = event.address.toHex().toString().concat(lockManager) as string;
+    store.remove('LockManager', lockManagerId);
+  })
+
+  store.remove('Lock', lockId);
 }
 
 function existingKeyTransfer(event: Transfer): void {

--- a/src/v7Mappings/mapping.ts
+++ b/src/v7Mappings/mapping.ts
@@ -1,4 +1,4 @@
-import { Address, Bytes, BigInt } from "@graphprotocol/graph-ts";
+import { Address, Bytes, BigInt, store } from "@graphprotocol/graph-ts";
 import { Lock, LockManager, KeyHolder, Key, KeyPurchase } from "../../generated/schema";
 import {
   ExpireKey,
@@ -8,7 +8,8 @@ import {
   LockManagerRemoved,
   PricingChanged,
   Transfer,
-  PublicLock
+  PublicLock,
+  Disable
 } from "../../generated/templates/PublicLock7/PublicLock";
 
 export function cancelKey(event: CancelKey): void {
@@ -83,6 +84,18 @@ export function transfer(event: Transfer): void {
   } else {
     existingKeyTransfer(event);
   }
+}
+
+export function handleDisable(event: Disable): void {  
+  let lockId = event.address.toHex().toString();
+  let lock = Lock.load(lockId) as Lock;
+
+  lock.LockManagers.forEach((lockManager) =>{
+    let lockManagerId = event.address.toHex().toString().concat(lockManager) as string;    
+    store.remove('LockManager', lockManagerId);
+  })
+
+  store.remove('Lock', lockId);
 }
 
 function newKeyPurchase(

--- a/subgraph.template.yaml
+++ b/subgraph.template.yaml
@@ -64,6 +64,8 @@ templates:
           handler: handleCancelKey
         - event: ExpireKey(uint256)
           handler: handleExpireKey
+        - event: Disable()
+          handler: handleDisable
 
       file: ./src/prev7Mappings/mapping.ts
 
@@ -96,6 +98,8 @@ templates:
           handler: pricingChanged
         - event: Transfer(indexed address,indexed address,indexed uint256)
           handler: transfer
+        - event: Disable()
+          handler: handleDisable          
 
       file: ./src/v7Mappings/mapping.ts
     


### PR DESCRIPTION
Reacting to an inbound request, when receiving a disable event from a lock contract we are now disassociating the lock owner and removing the lock owners and the lock contact from storage